### PR TITLE
Dbw node: Predictive Steering + PID changes

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -41,7 +41,7 @@ from styx_msgs.msg import Lane
 from twist_controller import Controller
 from yaw_controller import YawController
 
-PREDICTIVE_STEERING = 0.0 # from 0.0 to 1.0
+PREDICTIVE_STEERING = 1.0 # from 0.0 to 1.0
 
 
 class DBWNode(object):

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -39,9 +39,13 @@ from geometry_msgs.msg import TwistStamped, PoseStamped
 from styx_msgs.msg import Lane
 
 from twist_controller import Controller
+from yaw_controller import YawController
+
+PREDICTIVE_STEERING = 0.0 # from 0.0 to 1.0
 
 
 class DBWNode(object):
+    #pylint: disable=too-many-instance-attributes
     """
     Drive by Wire Node:
     The goal of this node is to get waypoint information and transform it
@@ -77,6 +81,7 @@ class DBWNode(object):
         steer_ratio = rospy.get_param('~steer_ratio', 14.8)
         max_lat_accel = rospy.get_param('~max_lat_accel', 3.)
         max_steer_angle = rospy.get_param('~max_steer_angle', 8.)
+        min_speed = 0.0
 
         self.steer_pub = rospy.Publisher('/vehicle/steering_cmd',
                                          SteeringCmd,
@@ -97,6 +102,8 @@ class DBWNode(object):
                            'max_steer_angle': max_steer_angle
                           }
         self.controller = Controller(**controller_args)
+        self.yaw_controller = YawController(
+            wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle)
 
         # Subscribe to all the topics you need to
         rospy.Subscriber('/vehicle/dbw_enabled', Bool,
@@ -141,9 +148,12 @@ class DBWNode(object):
                 throttle, brake, steer = self.controller.control(vel_error,
                                                                  cte,
                                                                  self.dbw_enabled)
-
+                # Get predicted steering angle from road curvature
+                yaw_steer = self.yaw_controller.get_steering(self.twist.linear.x,
+                                                             self.twist.angular.z,
+                                                             current_velocity)
             if self.dbw_enabled:
-                self.publish(throttle, brake, steer)
+                self.publish(throttle, brake, steer + PREDICTIVE_STEERING * yaw_steer)
 
             rate.sleep()
 

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -44,11 +44,11 @@ class Controller(object):
 
         # create controllers
         self.throttle_pid = pid.PID(kp=1.0, ki=0.02, kd=0.0, mn=mn, mx=mx)
-        self.steer_pid = pid.PID(kp=0.5, ki=0.001, kd=0.5, mn=-ms, mx=ms)
+        self.steer_pid = pid.PID(kp=0.088, ki=0.003, kd=0.15, mn=-ms, mx=ms)
 
         # create lowpass filters
         self.throttle_filter = lowpass.LowPassFilter(tau=0.10, ts=0.90)
-        self.steer_filter = lowpass.LowPassFilter(tau=0.10, ts=0.90)
+        self.steer_filter = lowpass.LowPassFilter(tau=0.00, ts=1.00)
 
         # init timestamp
         self.timestamp = rospy.get_time()

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -44,7 +44,7 @@ class Controller(object):
 
         # create controllers
         self.throttle_pid = pid.PID(kp=1.0, ki=0.02, kd=0.0, mn=mn, mx=mx)
-        self.steer_pid = pid.PID(kp=0.2, ki=0.001, kd=0.5, mn=-ms, mx=ms)
+        self.steer_pid = pid.PID(kp=0.5, ki=0.001, kd=0.5, mn=-ms, mx=ms)
 
         # create lowpass filters
         self.throttle_filter = lowpass.LowPassFilter(tau=0.10, ts=0.90)


### PR DESCRIPTION
The following changes were made

* Added predictive steering: 
       From twist_command, we get the target angular speed (which is due to road curvature). We used to calculate that in our code, but it's done by the system, so using that one instead. From that one, and yaw controller, we calculate a steering angle, due to road curvature (predictive steering). We add that to the corrective steering (due to cte) to get our new steering.
* The assistance of predictive steering is evident if we switch to high speeds
* When I add those steering angles I do steer + PREDICTIVE_STEERING * yaw_steer. PREDICTIVE STEERING is the ratio of yaw_steer you want to add. 0.0 to disable. 1.0 to include all (1.0 is default
* Practically disabled filtering in steering_angle (twist_controller line 51). The LowPassFilter just interpolates the previous value to the current one, with some weighting, to have smooth transitions.
I saw in higher speeds, in turns, that this actually hurts driving, because in turns we want sharp reactions, and slower reactions due to the filter lead to oscillations. 

Tested with speeds up to 80mph, and it drives fine (with minor oscillations) 