### PR TITLE
Dbw node update

### DIFF
--- a/ros/src/twist_controller/dbw_helper.py
+++ b/ros/src/twist_controller/dbw_helper.py
@@ -151,6 +151,6 @@ def cte(pose, waypoints):
     x_coords, y_coords = shift_and_rotate_waypoints(
         pose, waypoints, POINTS_TO_FIT)
     coefficients = np.polyfit(x_coords, y_coords, 3)
-    distance = np.polyval(coefficients, 0.0)
+    distance = np.polyval(coefficients, 5.0)
 
     return distance

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -42,7 +42,6 @@ from twist_controller import Controller
 from yaw_controller import YawController
 
 PREDICTIVE_STEERING = 1.0 # from 0.0 to 1.0
-REFERENCE_VELOCITY = 10 #mph
 
 class DBWNode(object):
     #pylint: disable=too-many-instance-attributes
@@ -128,7 +127,7 @@ class DBWNode(object):
                 target_velocity = self.waypoints[0].twist.twist.linear.x
                 current_velocity = self.velocity.linear.x
                 vel_error = target_velocity - current_velocity
-                correction = REFERENCE_VELOCITY/(current_velocity+1)
+                #correction = REFERENCE_VELOCITY/(current_velocity+1)
 
                 # Get predicted throttle, brake, and steering using `twist_controller`
                 throttle, brake, steer = self.controller.control(vel_error,
@@ -149,7 +148,7 @@ class DBWNode(object):
                 throttle, brake, steer = 0, 10000, 0
 
             if self.dbw_enabled:
-                self.publish(throttle, brake, steer * correction + PREDICTIVE_STEERING * yaw_steer)
+                self.publish(throttle, brake, steer + PREDICTIVE_STEERING * yaw_steer)
 
             rate.sleep()
 

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -40,6 +40,7 @@ from styx_msgs.msg import Lane
 
 from twist_controller import Controller
 from yaw_controller import YawController
+from speed_controller import SpeedController
 
 PREDICTIVE_STEERING = 1.0 # from 0.0 to 1.0
 
@@ -70,10 +71,10 @@ class DBWNode(object):
         self.twist = None
 
         # read ros parameters
-        # vehicle_mass = rospy.get_param('~vehicle_mass', 1736.35)
+        vehicle_mass = rospy.get_param('~vehicle_mass', 1736.35)
         # fuel_capacity = rospy.get_param('~fuel_capacity', 13.5)
         # brake_deadband = rospy.get_param('~brake_deadband', .1)
-        # wheel_radius = rospy.get_param('~wheel_radius', 0.2413)
+        wheel_radius = rospy.get_param('~wheel_radius', 0.2413)
         decel_limit = rospy.get_param('~decel_limit', -5)
         accel_limit = rospy.get_param('~accel_limit', 1.)
         wheel_base = rospy.get_param('~wheel_base', 2.8498)
@@ -86,18 +87,16 @@ class DBWNode(object):
         self.throttle_pub = rospy.Publisher('/vehicle/throttle_cmd', ThrottleCmd, queue_size=1)
         self.brake_pub = rospy.Publisher('/vehicle/brake_cmd', BrakeCmd, queue_size=1)
 
-        # Create `TwistController` object
-        controller_args = {'min_acc': decel_limit,
-                           'max_acc': accel_limit,
-                           'wheel_base': wheel_base,
-                           'steer_ratio': steer_ratio,
-                           'max_lat_acc': max_lat_accel,
-                           'max_steer_angle': max_steer_angle
-                          }
-
-        self.controller = Controller(**controller_args)
-        self.yaw_controller = YawController(
-            wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle)
+        self.controller = Controller(max_steer_angle)
+        self.speed_controller = SpeedController(vehicle_mass,
+                                                wheel_radius,
+                                                accel_limit,
+                                                decel_limit)
+        self.yaw_controller = YawController(wheel_base,
+                                            steer_ratio,
+                                            min_speed,
+                                            max_lat_accel,
+                                            max_steer_angle)
 
         # Subscribe to all the topics you need to
         rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_cb, queue_size=1)
@@ -126,26 +125,26 @@ class DBWNode(object):
                 cte = dbw_helper.cte(self.pose, self.waypoints)
                 target_velocity = self.waypoints[0].twist.twist.linear.x
                 current_velocity = self.velocity.linear.x
-                vel_error = target_velocity - current_velocity
-                #correction = REFERENCE_VELOCITY/(current_velocity+1)
 
-                # Get predicted throttle, brake, and steering using `twist_controller`
-                throttle, brake, steer = self.controller.control(vel_error,
-                                                                 cte,
-                                                                 self.dbw_enabled)
+                # Get corrected steering using `twist_controller`
+                steer = self.controller.control(cte, self.dbw_enabled)
 
                 # Get predicted steering angle from road curvature
                 yaw_steer = self.yaw_controller.get_steering(self.twist.linear.x,
                                                              self.twist.angular.z,
                                                              current_velocity)
 
+                throttle, brake = self.speed_controller.control(target_velocity,
+                                                                current_velocity,
+                                                                0.5)
+
                 # Apply full deacceleration if target velocity is zero
-                brake = 10000 if self.twist.linear.x == 0 else brake
+                brake = 20000 if self.twist.linear.x == 0 else brake
 
             else:
                 # if too few waypoints and publish a hard break
                 rospy.logwarn("Number of waypoint received: %s", len(self.waypoints))
-                throttle, brake, steer = 0, 10000, 0
+                throttle, brake, steer = 0, 20000, 0
 
             if self.dbw_enabled:
                 self.publish(throttle, brake, steer + PREDICTIVE_STEERING * yaw_steer)

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -139,7 +139,7 @@ class DBWNode(object):
                                                                 0.5)
 
                 # Apply full deacceleration if target velocity is zero
-                brake = 20000 if self.twist.linear.x == 0 else brake
+                # brake = 20000 if self.twist.linear.x == 0 else brake
 
             else:
                 # if too few waypoints and publish a hard break

--- a/ros/src/twist_controller/speed_controller.py
+++ b/ros/src/twist_controller/speed_controller.py
@@ -1,0 +1,55 @@
+#-------------------------------------------------------------------------------
+# Author: Kostas Oreopoulos <kostas.oreopoulos@gmail.com>
+# Date:   28.08.17
+#-------------------------------------------------------------------------------
+"""
+A speed pid controller based on torque for dbw node
+"""
+
+MAX_THROTTLE_TORQUE = 2000.0
+MAX_BREAK_TORQUE = 20000.0
+
+
+class SpeedController(object):
+    """ A Speed Controller class """
+    # pylint: disable=too-few-public-methods
+    def __init__(self, vehicle_mass, wheel_radius, accel_limit, decel_limit):
+        self.vehicle_mass = vehicle_mass
+        self.wheel_radius = wheel_radius
+        self.accel_limit = accel_limit
+        self.decel_limit = decel_limit
+
+    def control(self, target_velocity, current_velocity, realization_time):
+        """
+        Given the velocity error and the time elapsed
+        since previous step it returns the correct throttle brake combination
+
+        Args:
+             target_velocity (float) : the target velocity of the car
+             current_velocity (float) : the current velocity the car
+             realization_time (float): The time to make the transition
+
+        Returns:
+             throttle (float) , brake (float)
+        """
+        # calculate change that needs to take place
+        error = target_velocity - current_velocity
+        # calculate the acceleration based on the time
+        # we need to make the change happen
+        acceleration = error / realization_time
+        # apply limits to acceleration
+        if acceleration > 0:
+            acceleration = min(self.accel_limit, acceleration)
+        else:
+            acceleration = max(self.decel_limit, acceleration)
+        # calculate torque = M*acc*R
+        torque = self.vehicle_mass * acceleration * self.wheel_radius
+        throttle, brake = 0, 0
+        if torque > 0:
+            # throttle is the percent of max torque applied
+            throttle, brake = min(1.0, torque / MAX_THROTTLE_TORQUE), 0.0
+        else:
+            # brake is the torque we need to apply
+            throttle, brake = 0.0, min(abs(torque), MAX_BREAK_TORQUE)
+
+        return throttle, brake

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -33,33 +33,22 @@ class Controller(object):
 
     """
 
-    def __init__(self, **kwargs):
-        mn = kwargs.get('min_acc', 0.0)  # decel_limit
-        mx = kwargs.get('max_acc', 0.0)  # accel_limit
-        # wb = kwargs.get('wheel_base', 0.0)  # wheel_base
-        # sr = kwargs.get('steer_ratio', 0.0)  # steer_ratio
-        # ml = kwargs.get('max_lat_acc', 0.0)  # max_lat_accel
-        ms = kwargs.get('max_steer_angle', 0.0)  # max_steer_angle
-        # min_speed = 0.0
+    def __init__(self, max_steer_angle):
+        ms = max_steer_angle  # max_steer_angle
 
         # create controllers
-        self.throttle_pid = pid.PID(kp=1.0, ki=0.02, kd=0.0, mn=mn, mx=mx)
         self.steer_pid = pid.PID(kp=0.5, ki=0.003, kd=0.25, mn=-ms, mx=ms)
-
         # create lowpass filters
-        self.throttle_filter = lowpass.LowPassFilter(tau=0.10, ts=0.90)
         self.steer_filter = lowpass.LowPassFilter(tau=0., ts=1.)
-
         # init timestamp
         self.timestamp = rospy.get_time()
 
-    def control(self, vel_error, cte, dbw_enabled):
+    def control(self, cte, dbw_enabled):
         """
         Given then target linear and angular velocities, as well as the current velocity
         calculate the CTE and pass them to the corresponding PID's
 
         Args:
-             vel_error (float) : Velocity Error
              cte (float): Cross Track Error
              dbw_enabled (bool) : If True: auto pilot is on. If False: Manual driving
         """
@@ -69,25 +58,13 @@ class Controller(object):
 
         self.timestamp = new_timestamp
         if dbw_enabled:
-            # initialize values
-            brake = 0.
-            throttle = 0.
             # filter (smooth) errors
             cte = self.steer_filter.filt(cte)
-            vel_error = self.throttle_filter.filt(vel_error)
             # calculate new steering angle
             steering_angle = self.steer_pid.step(cte, sample_time)
-            # caclulate throttle and brake
-            throttle = self.throttle_pid.step(vel_error, sample_time)
-            # convert to the expected format
-            if throttle < 0.:
-                brake = 1000 * abs(throttle)
-                throttle = 0.
-            return throttle, brake, steering_angle
+            return steering_angle
         # dbw is not enabled (manual override) so resetting pid's and filters
-        self.throttle_pid.reset()
         self.steer_pid.reset()
-        self.throttle_filter.last_val = 0.0
         self.steer_filter.last_val = 0.0
 
-        return 0.0, 0.0, 0.0
+        return 0.0

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -44,11 +44,11 @@ class Controller(object):
 
         # create controllers
         self.throttle_pid = pid.PID(kp=1.0, ki=0.02, kd=0.0, mn=mn, mx=mx)
-        self.steer_pid = pid.PID(kp=0.088, ki=0.003, kd=0.15, mn=-ms, mx=ms)
+        self.steer_pid = pid.PID(kp=0.5, ki=0.003, kd=0.25, mn=-ms, mx=ms)
 
         # create lowpass filters
         self.throttle_filter = lowpass.LowPassFilter(tau=0.10, ts=0.90)
-        self.steer_filter = lowpass.LowPassFilter(tau=0.00, ts=1.00)
+        self.steer_filter = lowpass.LowPassFilter(tau=0., ts=1.)
 
         # init timestamp
         self.timestamp = rospy.get_time()
@@ -72,15 +72,16 @@ class Controller(object):
             # initialize values
             brake = 0.
             throttle = 0.
+            # filter (smooth) errors
+            cte = self.steer_filter.filt(cte)
+            vel_error = self.throttle_filter.filt(vel_error)
             # calculate new steering angle
             steering_angle = self.steer_pid.step(cte, sample_time)
-            steering_angle = self.steer_filter.filt(steering_angle)
             # caclulate throttle and brake
             throttle = self.throttle_pid.step(vel_error, sample_time)
-            throttle = self.throttle_filter.filt(throttle)
             # convert to the expected format
             if throttle < 0.:
-                brake = throttle
+                brake = 1000 * abs(throttle)
                 throttle = 0.
             return throttle, brake, steering_angle
         # dbw is not enabled (manual override) so resetting pid's and filters


### PR DESCRIPTION
 - Change how we calculate CTE. Since we lowered the rate AND changed the message queue to the sim, the behavior of the controller changed. It looks as we are a bit late always. So instead of calculating the CTE at x=0, I do at x=5.0. I checked at various positions and it seems this value to be best. Also, it is in "sync" with the 1/5th of the rate we now have. Also now the vehicle drives fine in lane at all speeds (which I tried)

- Changed PID coefficients
- Changed filter application. Now the filter is applied to the errors (although the filter is disabled for now)
- Created a speed controller, based on torque
- Removed the old throttle PID from the controller
- Replaced with the new speed controller in dbw_node
- the usage is SpeedController.control(target_v, current_v, realization_time) . Realization time is the time I want that change to happen.
- Commented the code that we used to stop the car if speed is zero. It works fine without it now, but I did not delete it, in case we have problems.

It looks very stable now. Start and stop at traffic light works