### PR TITLE
Dbw node minor changes

### DIFF
--- a/ros/src/twist_controller/pid.py
+++ b/ros/src/twist_controller/pid.py
@@ -18,7 +18,7 @@ class PID(object):
     A simple PID controller object
     """
 
-    def __init__(self, kp=0.0, ki=0.0, kd=0.0, mn=MIN_NUM, mx=MAX_NUM):
+    def __init__(self, kp=0.0, ki=0.0, kd=0.0, mn=MIN_NUM, mx=MAX_NUM, lowpass_filter=None):
         # pylint: disable=too-many-arguments
         self.kp = kp
         self.ki = ki
@@ -27,6 +27,7 @@ class PID(object):
         self.max = mx
 
         self.int_val = self.last_int_val = self.last_error = 0.
+        self.filter = lowpass_filter
 
     def reset(self):
         """
@@ -54,10 +55,11 @@ class PID(object):
         integral = self.int_val + error * sample_time
         derivative = (error - self.last_error) / sample_time
 
+        if self.filter is not None:
+            derivative = self.filter.filt(derivative)
+
         y = self.kp * error + self.ki * self.int_val + self.kd * derivative
         val = max(self.min, min(y, self.max))
-        print("PID :  result {}  CTE {} derivative {} integral {} ".format(
-            y, error, derivative, integral))
 
         if val > self.max:
             val = self.max

--- a/ros/src/twist_controller/speed_controller.py
+++ b/ros/src/twist_controller/speed_controller.py
@@ -6,7 +6,7 @@
 A speed pid controller based on torque for dbw node
 """
 
-MAX_THROTTLE_TORQUE = 2000.0
+MAX_THROTTLE_TORQUE = 200.0
 MAX_BREAK_TORQUE = 20000.0
 
 

--- a/ros/src/twist_controller/speed_controller.py
+++ b/ros/src/twist_controller/speed_controller.py
@@ -37,7 +37,7 @@ class SpeedController(object):
         # calculate the acceleration based on the time
         # we need to make the change happen
         acceleration = error / realization_time
-        # apply limits to acceleration
+        # apply limits to acceleration (useless since we use torque limits)
         if acceleration > 0:
             acceleration = min(self.accel_limit, acceleration)
         else:

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -36,10 +36,13 @@ class Controller(object):
     def __init__(self, max_steer_angle):
         ms = max_steer_angle  # max_steer_angle
 
-        # create controllers
-        self.steer_pid = pid.PID(kp=0.5, ki=0.003, kd=0.25, mn=-ms, mx=ms)
         # create lowpass filters
-        self.steer_filter = lowpass.LowPassFilter(tau=0., ts=1.)
+        self.steer_filter = lowpass.LowPassFilter(tau=0.0, ts=1.0)
+        # override filter. It induces lag. Here for reference on how to use
+        self.steer_filter = None
+        # create controllers
+        self.steer_pid = pid.PID(kp=0.5, ki=0.003, kd=0.25,
+                                 mn=-ms, mx=ms, lowpass_filter=self.steer_filter)
         # init timestamp
         self.timestamp = rospy.get_time()
 
@@ -58,8 +61,6 @@ class Controller(object):
 
         self.timestamp = new_timestamp
         if dbw_enabled:
-            # filter (smooth) errors
-            cte = self.steer_filter.filt(cte)
             # calculate new steering angle
             steering_angle = self.steer_pid.step(cte, sample_time)
             return steering_angle


### PR DESCRIPTION
* Change speed controller. The limits (acceleration and deceleration are obsolete and not useful). Torque limits are used and they were capped by those limits. Changed acceleration torque limit to make the car able to drive faster 

* Moved filter inside the PID controller and applied it correctly (according to the robotics ND lessons) to the error derivate.

* After experimentation, the filter does not help, since it induces lag, and since there is already a lot of lag, set the filter to None for now and maybe re-enable later

The car drives perfectly up to 60mph, then we start to see a little of oscillation as the speed increases.
My guess is that for such high speed we need lower latency.